### PR TITLE
Drop 'plugin' from the name of the package.

### DIFF
--- a/development/docker-compose.base.yml
+++ b/development/docker-compose.base.yml
@@ -7,7 +7,7 @@ x-nautobot-build: &nautobot-build
     context: "../"
     dockerfile: "development/Dockerfile"
 x-nautobot-base: &nautobot-base
-  image: "nautobot-plugin-device-lifecycle-mgmt/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
+  image: "nautobot-device-lifecycle-mgmt/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
   env_file:
     - "dev.env"
     - "creds.env"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "nautobot-plugin-device-lifecycle-mgmt"
+name = "nautobot-device-lifecycle-mgmt"
 version = "1.0.0-beta.0"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Mikhail Yohman <mikhail.yohman@gmail.com>"]


### PR DESCRIPTION
Removes `plugin` from the name of the package in `pyproject.toml` and from the name of the container image in `docker-compose.base.yml`.