### PR TITLE
Update release_date and end_of_support filters for SoftwareLCM.

### DIFF
--- a/nautobot_device_lifecycle_mgmt/filters.py
+++ b/nautobot_device_lifecycle_mgmt/filters.py
@@ -91,6 +91,9 @@ class SoftwareLCMFilterSet(django_filters.FilterSet):
         label="Device Platform (Slug)",
     )
 
+    release_date = django_filters.DateTimeFromToRangeFilter()
+    end_of_support = django_filters.DateTimeFromToRangeFilter()
+
     class Meta:
         """Meta attributes for filter."""
 
@@ -99,8 +102,6 @@ class SoftwareLCMFilterSet(django_filters.FilterSet):
         fields = [
             "version",
             "alias",
-            "release_date",
-            "end_of_support",
             "documentation_url",
             "download_url",
             "image_file_name",

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -165,6 +165,10 @@ class SoftwareLCMFilterForm(BootstrapMixin, forms.ModelForm):
     device_platform = forms.ModelMultipleChoiceField(
         required=False, queryset=Platform.objects.all(), to_field_name="slug"
     )
+    release_date_before = forms.DateField(label="Release Date Before", required=False, widget=DatePicker())
+    release_date_after = forms.DateField(label="Release Date After", required=False, widget=DatePicker())
+    end_of_support_before = forms.DateField(label="End of Software Support Before", required=False, widget=DatePicker())
+    end_of_support_after = forms.DateField(label="End of Software Support After", required=False, widget=DatePicker())
 
     class Meta:
         """Meta attributes."""
@@ -174,8 +178,10 @@ class SoftwareLCMFilterForm(BootstrapMixin, forms.ModelForm):
             "q",
             "version",
             "device_platform",
-            "release_date",
-            "end_of_support",
+            "release_date_before",
+            "release_date_after",
+            "end_of_support_before",
+            "end_of_support_after",
             "documentation_url",
             "download_url",
             "image_file_name",
@@ -185,8 +191,6 @@ class SoftwareLCMFilterForm(BootstrapMixin, forms.ModelForm):
         ]
 
         widgets = {
-            "release_date": DatePicker(),
-            "end_of_support": DatePicker(),
             "long_term_support": StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
             "pre_release": StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
         }


### PR DESCRIPTION
Updates filter fields `release_date` and `end_of_support`, in the `SoftwareLCM` list view, to use date ranges instead of the exact date matching.