### PR TITLE
Use DjangoObject from Graphene lib. Remove GQL types for models that already use the decorator.

### DIFF
--- a/nautobot_device_lifecycle_mgmt/__init__.py
+++ b/nautobot_device_lifecycle_mgmt/__init__.py
@@ -7,9 +7,16 @@ except ImportError:
 
 __version__ = metadata.version(__name__)
 
+from packaging import version
+
+from django.conf import settings
 from django.db.models.signals import post_migrate
 
 from nautobot.extras.plugins import PluginConfig
+
+
+current_nautobot_version = version.parse(settings.VERSION)
+NAUTOBOT_GRAPHQL_FIX = version.parse("1.2.0b1")
 
 
 class DeviceLifeCycleConfig(PluginConfig):
@@ -30,21 +37,14 @@ class DeviceLifeCycleConfig(PluginConfig):
 
     def ready(self):
         """Register custom signals."""
-        import graphene  # pylint: disable=import-outside-toplevel
-        from graphene_django.converter import convert_django_field  # pylint: disable=import-outside-toplevel
-        from taggit.managers import TaggableManager  # pylint: disable=import-outside-toplevel
-        from nautobot.extras.graphql.types import TagType  # pylint: disable=import-outside-toplevel
-
         import nautobot_device_lifecycle_mgmt.signals  # pylint: disable=C0415,W0611 # noqa: F401
-
-        @convert_django_field.register(TaggableManager)
-        def convert_field_to_list_tags(field, registry=None):
-            """Convert TaggableManager to List of Tags."""
-            return graphene.List(TagType)
-
         from .signals import (  # pylint: disable=import-outside-toplevel
             post_migrate_create_relationships,
         )
+
+        # Workaround for https://github.com/nautobot/nautobot/issues/567 for Nautobot < 1.2.0b1
+        if current_nautobot_version < NAUTOBOT_GRAPHQL_FIX:
+            import nautobot.extras.graphql.types  # pylint: disable=import-outside-toplevel, unused-import # noqa: F401
 
         post_migrate.connect(post_migrate_create_relationships, sender=self)
 

--- a/nautobot_device_lifecycle_mgmt/__init__.py
+++ b/nautobot_device_lifecycle_mgmt/__init__.py
@@ -30,14 +30,25 @@ class DeviceLifeCycleConfig(PluginConfig):
 
     def ready(self):
         """Register custom signals."""
-        super().ready()
+        import graphene  # pylint: disable=import-outside-toplevel
+        from graphene_django.converter import convert_django_field  # pylint: disable=import-outside-toplevel
+        from taggit.managers import TaggableManager  # pylint: disable=import-outside-toplevel
+        from nautobot.extras.graphql.types import TagType  # pylint: disable=import-outside-toplevel
+
         import nautobot_device_lifecycle_mgmt.signals  # pylint: disable=C0415,W0611 # noqa: F401
+
+        @convert_django_field.register(TaggableManager)
+        def convert_field_to_list_tags(field, registry=None):
+            """Convert TaggableManager to List of Tags."""
+            return graphene.List(TagType)
 
         from .signals import (  # pylint: disable=import-outside-toplevel
             post_migrate_create_relationships,
         )
 
         post_migrate.connect(post_migrate_create_relationships, sender=self)
+
+        super().ready()
 
 
 config = DeviceLifeCycleConfig  # pylint:disable=invalid-name

--- a/nautobot_device_lifecycle_mgmt/graphql/types.py
+++ b/nautobot_device_lifecycle_mgmt/graphql/types.py
@@ -1,61 +1,14 @@
 """GraphQL implementation for the Device LifeCycle Management plugin."""
 import graphene
 
-from nautobot.extras.graphql.types import DjangoObjectType
+from graphene_django import DjangoObjectType
+
 from nautobot_device_lifecycle_mgmt.models import (
-    HardwareLCM,
-    ContractLCM,
-    ProviderLCM,
-    ContactLCM,
     ValidatedSoftwareLCM,
 )
 from nautobot_device_lifecycle_mgmt.filters import (
-    HardwareLCMFilterSet,
-    ContractLCMFilterSet,
-    ProviderLCMFilterSet,
-    ContactLCMFilterSet,
     ValidatedSoftwareLCMFilterSet,
 )
-
-
-class HardwareLCMType(DjangoObjectType):
-    """Graphql Type Object for the Device Lifecycle model."""
-
-    class Meta:
-        """Metadata magic method for the HardwareLCMType."""
-
-        model = HardwareLCM
-        filterset_class = HardwareLCMFilterSet
-
-
-class ContractLCMType(DjangoObjectType):
-    """Graphql Type Object for the Device Lifecycle model."""
-
-    class Meta:
-        """Metadata magic method for the ContractLCMType."""
-
-        model = ContractLCM
-        filterset_class = ContractLCMFilterSet
-
-
-class ProviderLCMType(DjangoObjectType):
-    """Graphql Type Object for the Device Lifecycle model."""
-
-    class Meta:
-        """Metadata magic method for the ProviderLCMType."""
-
-        model = ProviderLCM
-        filterset_class = ProviderLCMFilterSet
-
-
-class ContactLCMType(DjangoObjectType):
-    """Graphql Type Object for the Device Lifecycle model."""
-
-    class Meta:
-        """Metadata magic method for the ContactLCMType."""
-
-        model = ContactLCM
-        filterset_class = ContactLCMFilterSet
 
 
 class ValidatedSoftwareLCMType(DjangoObjectType):
@@ -71,9 +24,5 @@ class ValidatedSoftwareLCMType(DjangoObjectType):
 
 
 graphql_types = [
-    HardwareLCMType,
-    ContractLCMType,
-    ProviderLCMType,
-    ContactLCMType,
     ValidatedSoftwareLCMType,
 ]


### PR DESCRIPTION
- Imports `DjangoObject` from Graphene lib directly instead of using the Nautobot reference.
- Remove GraphQL types for models that already have GraphQL types through the `@extras_features` decorator.
- Add to the plugin's `ready()` method GraphQL override for the `TaggableManager` representation.
  This is copied from the core. Without it GraphQL can't auto-convert `tags` field on manually defined types. This worked previously because importing `DjangoObject` from the Nautobot modules triggerred execution of the code that does it in the core.