### PR TITLE
Define empty button lists for nav items that don't use buttons

### DIFF
--- a/nautobot_device_lifecycle_mgmt/navigation.py
+++ b/nautobot_device_lifecycle_mgmt/navigation.py
@@ -193,6 +193,7 @@ try:
                         NavMenuItem(
                             link="plugins:nautobot_device_lifecycle_mgmt:validatedsoftware_device_report",
                             name="Device Software Validation",
+                            buttons=(),
                             permissions=[
                                 "nautobot_device_lifecycle_mgmt.view_validatedsoftwarelcm",
                             ],
@@ -200,6 +201,7 @@ try:
                         NavMenuItem(
                             link="plugins:nautobot_device_lifecycle_mgmt:validatedsoftware_inventoryitem_report",
                             name="Inventory Item Software Validation",
+                            buttons=(),
                             permissions=[
                                 "nautobot_device_lifecycle_mgmt.view_validatedsoftwarelcm",
                             ],
@@ -336,9 +338,11 @@ except ModuleNotFoundError:
         PluginMenuItem(
             link="plugins:nautobot_device_lifecycle_mgmt:validatedsoftware_device_report",
             link_text="Report: Device OS Validation",
+            buttons=(),
         ),
         PluginMenuItem(
             link="plugins:nautobot_device_lifecycle_mgmt:validatedsoftware_inventoryitem_report",
             link_text="Report: Inventory Item OS Validation",
+            buttons=(),
         ),
     )


### PR DESCRIPTION
A potential bug appeared while testing under Nautobot 1.2.0beta1 caused by some of the Nav Menu items not declaring value for `buttons` argument.

This PR adds explicit empty button list definitions for the Nav Items that don't use buttons to avoid trigerring this potential bug.