### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.4.0 - 02-08-2022
+- PR#47: Added Plugin Upgrade Guide to the README
+- PR#50: Fixed view permissions for Device Notices
+- PR#57: Added CVE Tracking model and Vulnerability model
+
 ## v0.3.0 - 12-14-2021
 
 - PR#39: Adds feature-rich reporting functionality for Software Validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "0.3.0"
+version = "0.4.0"
 description = "Manages device lifecycles for platforms and software."
 authors = [
     "Josh Silvas <josh.silvas@networktocode.com>",


### PR DESCRIPTION
## v0.4.0 - 02-08-2022
- PR#47: Added Plugin Upgrade Guide to the README
- PR#50: Fixed view permissions for Device Notices
- PR#57: Added CVE Tracking model and Vulnerability model