### PR TITLE
Renamed CustomFieldModelFilterSet to CustomFieldModelFilterSetMixin

### DIFF
--- a/nautobot_device_lifecycle_mgmt/api/serializers.py
+++ b/nautobot_device_lifecycle_mgmt/api/serializers.py
@@ -7,7 +7,7 @@ from nautobot.dcim.api.nested_serializers import (
     NestedPlatformSerializer,
 )
 from nautobot.extras.api.serializers import (
-    CustomFieldModelSerializerMixin,
+    CustomFieldModelSerializer,
     StatusModelSerializerMixin,
     StatusSerializerField,
     TaggedObjectSerializer,
@@ -22,10 +22,10 @@ try:
     serializer_base_classes = [
         RelationshipModelSerializerMixin,
         TaggedObjectSerializer,
-        CustomFieldModelSerializerMixin,
+        CustomFieldModelSerializer,
     ]  # pylint: disable=invalid-name
 except ImportError:
-    serializer_base_classes = [TaggedObjectSerializer, CustomFieldModelSerializerMixin]  # pylint: disable=invalid-name
+    serializer_base_classes = [TaggedObjectSerializer, CustomFieldModelSerializer]  # pylint: disable=invalid-name
 
 from nautobot.extras.models import Status
 

--- a/nautobot_device_lifecycle_mgmt/api/serializers.py
+++ b/nautobot_device_lifecycle_mgmt/api/serializers.py
@@ -6,8 +6,9 @@ from nautobot.dcim.api.nested_serializers import (
     NestedInventoryItemSerializer,
     NestedPlatformSerializer,
 )
+from nautobot.extras.api.customfields import CustomFieldModelSerializer
 from nautobot.extras.api.serializers import (
-    CustomFieldModelSerializer,
+    CustomFieldModelSerializerMixin,
     StatusModelSerializerMixin,
     StatusSerializerField,
     TaggedObjectSerializer,

--- a/nautobot_device_lifecycle_mgmt/api/serializers.py
+++ b/nautobot_device_lifecycle_mgmt/api/serializers.py
@@ -8,7 +8,6 @@ from nautobot.dcim.api.nested_serializers import (
 )
 from nautobot.extras.api.customfields import CustomFieldModelSerializer
 from nautobot.extras.api.serializers import (
-    CustomFieldModelSerializerMixin,
     StatusModelSerializerMixin,
     StatusSerializerField,
     TaggedObjectSerializer,

--- a/nautobot_device_lifecycle_mgmt/api/serializers.py
+++ b/nautobot_device_lifecycle_mgmt/api/serializers.py
@@ -7,7 +7,7 @@ from nautobot.dcim.api.nested_serializers import (
     NestedPlatformSerializer,
 )
 from nautobot.extras.api.serializers import (
-    CustomFieldModelSerializer,
+    CustomFieldModelSerializerMixin,
     StatusModelSerializerMixin,
     StatusSerializerField,
     TaggedObjectSerializer,
@@ -22,10 +22,10 @@ try:
     serializer_base_classes = [
         RelationshipModelSerializerMixin,
         TaggedObjectSerializer,
-        CustomFieldModelSerializer,
+        CustomFieldModelSerializerMixin,
     ]  # pylint: disable=invalid-name
 except ImportError:
-    serializer_base_classes = [TaggedObjectSerializer, CustomFieldModelSerializer]  # pylint: disable=invalid-name
+    serializer_base_classes = [TaggedObjectSerializer, CustomFieldModelSerializerMixin]  # pylint: disable=invalid-name
 
 from nautobot.extras.models import Status
 


### PR DESCRIPTION
This should fix #122. `nautobot-server post_upgrade` failed after the upgrade to Nautobot 1.5.2 with this plugin installed due to renamed mixin classes in Nautobot.