### PR TITLE
Add log_info for each CVE in the vulnerability job

### DIFF
--- a/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
+++ b/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
@@ -1,7 +1,7 @@
 """Jobs for the CVE Tracking portion of the Device Lifecycle plugin."""
 from datetime import datetime
 
-from nautobot.extras.jobs import Job, StringVar
+from nautobot.extras.jobs import Job, StringVar, BooleanVar
 from nautobot.extras.models import Relationship, RelationshipAssociation
 
 from nautobot_device_lifecycle_mgmt.models import (
@@ -31,6 +31,9 @@ class GenerateVulnerabilities(Job):
         """Meta class for the job."""
 
         commit_default = True
+        field_order = ["published_after", "_task_queue", "debug", "_commit"]
+
+    debug = BooleanVar(description="Enable for more verbose logging.")
 
     def run(self, data, commit):  # pylint: disable=too-many-locals
         """Check if software assigned to each device is valid. If no software is assigned return warning message."""
@@ -40,7 +43,8 @@ class GenerateVulnerabilities(Job):
         count_before = VulnerabilityLCM.objects.count()
 
         for cve in cves:
-            self.log_info(obj=cve, message="Generating vulnerabilities for CVE {cve}")
+            if data["debug"]:
+                self.log_info(obj=cve, message="Generating vulnerabilities for CVE {cve}")
             software_rels = RelationshipAssociation.objects.filter(relationship__slug="soft_cve", destination_id=cve.id)
             for soft_rel in software_rels:
 


### PR DESCRIPTION
When a generate vulnerability job takes a long time, I wanted to be able to have some indication of the progress of the job. This gives some info without being too verbose. I did consider making this contingent on a `debug` like many jobs are but ultimately decided to put it as a `log_info`.  I'm definitely open to either approach or no log message at all. 