### PR TITLE
Define default columns for Software list view

### DIFF
--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -135,6 +135,18 @@ class SoftwareLCMTable(BaseTable):
             "pre_release",
             "actions",
         )
+        default_columns = (
+            "pk",
+            "name",
+            "version",
+            "alias",
+            "device_platform",
+            "release_date",
+            "end_of_support",
+            "long_term_support",
+            "pre_release",
+            "actions",
+        )
 
 
 class SoftwareImageLCMTable(BaseTable):


### PR DESCRIPTION
This PR defines default columns displayed in the Software list view. This will stop relationship columns from being displayed by default.

Addresses #159