### PR TITLE
Add download url column to SoftwareImage table

### DIFF
--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -168,6 +168,13 @@ class SoftwareImageLCMTable(BaseTable):
     )
     default_image = BooleanColumn()
     actions = ButtonsColumn(SoftwareImageLCM, buttons=("edit", "delete"))
+    download_url = tables.TemplateColumn(
+        template_code="""{% if record.download_url %}
+                    <a href="{{ record.download_url }}" target="_blank" data-toggle="tooltip" data-placement="left" title="{{ record.download_url }}">
+                        <span class="mdi mdi-open-in-new"></span>
+                    </a>{% else %} — {% endif %}""",
+        verbose_name="Download URL",
+    )
 
     class Meta(BaseTable.Meta):  # pylint: disable=too-few-public-methods
         """Meta attributes."""
@@ -180,6 +187,7 @@ class SoftwareImageLCMTable(BaseTable):
             "device_type_count",
             "object_tag_count",
             "default_image",
+            "download_url",
             "actions",
         )
 


### PR DESCRIPTION
Adding download link column to the software list page for easy access. 

https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/issues/169

![image](https://user-images.githubusercontent.com/76115401/234325850-0d169b94-2f13-4c86-94ec-6e4609b19837.png)
