### PR TITLE
Make HW End Of Support metric names consistent

### DIFF
--- a/nautobot_device_lifecycle_mgmt/metrics.py
+++ b/nautobot_device_lifecycle_mgmt/metrics.py
@@ -21,7 +21,7 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
         labels=["part_number"],
     )
     hw_end_of_support_site_gauge = GaugeMetricFamily(
-        "nautobot_lcm_devices_eos_per_site", "Nautobot LCM Hardware End of Support per Site", labels=["site"]
+        "nautobot_lcm_hw_end_of_support_per_site", "Nautobot LCM Hardware End of Support per Site", labels=["site"]
     )
 
     today = datetime.today().date()


### PR DESCRIPTION
- Updates HW End Of Support per site metric to be consistent with the HW End Of Support per part number metric.