### PR TITLE
Add enhancments to clarify inventory items

### DIFF
--- a/nautobot_device_lifecycle_mgmt/models.py
+++ b/nautobot_device_lifecycle_mgmt/models.py
@@ -519,6 +519,8 @@ class InventoryItemSoftwareValidationResult(PrimaryModel):
 
     csv_headers = [
         "inventory_item",
+        "item_name",
+        "device",
         "software",
         "valid",
         "last_run",
@@ -536,12 +538,25 @@ class InventoryItemSoftwareValidationResult(PrimaryModel):
         """Indicates model fields to return as csv."""
         return (
             self.inventory_item.part_id,
+            self.inventory_item.name,
+            self.inventory_item.device.name,
             self.software if self.software else "None",
             str(self.is_validated),
             self.last_run.strftime("%Y-%m-%d %H:%M:%S") if self.last_run else "-",
             self.run_type,
             ",".join(str(valid.software) for valid in ValidatedSoftwareLCM.objects.get_for_object(self.inventory_item)),
         )
+
+    def __str__(self):
+        """String representation of InventoryItemSoftwareValidationResult."""
+        if self.is_validated:
+            msg = f"Inventory Item: {self.inventory_item.name} - " f"Device: {self.inventory_item.device.name} - Valid"
+        else:
+            msg = (
+                f"Inventory Item: {self.inventory_item.name} - "
+                f"Device: {self.inventory_item.device.name} - Not Valid"
+            )
+        return msg
 
 
 @extras_features(

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -230,7 +230,9 @@ class DeviceSoftwareValidationResultTable(BaseTable):
 
     name = tables.TemplateColumn(
         template_code='<a href="/plugins/nautobot-device-lifecycle-mgmt/device-validated-software-result/'
-        '?&device_type={{ record.device__device_type__model }}">{{ record.device__device_type__model }}</a>'
+        '?&device_type={{ record.device__device_type__model }}">{{ record.device__device_type__model }}</a>',
+        orderable=True,
+        accessor="device__device_type__model",
     )
     total = tables.TemplateColumn(
         template_code='<a href="/plugins/nautobot-device-lifecycle-mgmt/device-validated-software-result/'
@@ -313,7 +315,19 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         <a href="/plugins/nautobot-device-lifecycle-mgmt/inventory-item-validated-software-result/?&part_id={{ record.inventory_item__part_id }}">{{ record.inventory_item__part_id }}</a>
         {% else %}
         Please assign Part ID value to Inventory Item
-        {% endif %}"""
+        {% endif %}""",
+        orderable=True,
+        accessor="inventory_item__part_id",
+    )
+    part_name = tables.TemplateColumn(
+        template_code="{{ record.inventory_item__name }}",
+        orderable=True,
+        accessor="inventory_item__name",
+    )
+    device = tables.TemplateColumn(
+        template_code="{{ record.inventory_item__device__name }}",
+        orderable=True,
+        accessor="inventory_item__device__name",
     )
     total = tables.TemplateColumn(
         template_code='<a href="/plugins/nautobot-device-lifecycle-mgmt/inventory-item-validated-software-result/'
@@ -342,9 +356,11 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         """Metaclass attributes of InventoryItemSoftwareValidationResultTable."""
 
         model = InventoryItemSoftwareValidationResult
-        fields = ["part_id", "total", "valid", "invalid", "no_software", "valid_percent"]
+        fields = ["part_id", "part_name", "device", "total", "valid", "invalid", "no_software", "valid_percent"]
         default_columns = [
             "part_id",
+            "part_name",
+            "device",
             "total",
             "valid",
             "invalid",
@@ -362,6 +378,13 @@ class InventoryItemSoftwareValidationResultListTable(BaseTable):
         verbose_name="Part ID",
         default="Please assign Part ID value to Inventory Item",
     )
+    part_name = tables.TemplateColumn(
+        template_code="""<a href='/dcim/inventory-items/{{ record.inventory_item.pk }}'>
+                        {{ record.inventory_item.name }}</a>""",
+        verbose_name="Part Name",
+        accessor="inventory_item__name",
+    )
+    device_name = tables.Column(accessor="inventory_item__device__name", verbose_name="Device")
     software = tables.Column(accessor="software", verbose_name="Current Software", linkify=True)
     valid = tables.Column(accessor="is_validated", verbose_name="Valid")
     last_run = tables.Column(accessor="last_run", verbose_name="Last Run")
@@ -381,9 +404,11 @@ class InventoryItemSoftwareValidationResultListTable(BaseTable):
         """Metaclass attributes of InventoryItemSoftwareValidationResultTable."""
 
         model = InventoryItemSoftwareValidationResult
-        fields = ["part_id", "software", "valid", "last_run", "run_type", "valid_software"]
+        fields = ["part_id", "part_name", "device_name", "software", "valid", "last_run", "run_type", "valid_software"]
         default_columns = [
             "part_id",
+            "part_name",
+            "device_name",
             "software",
             "valid",
             "last_run",

--- a/nautobot_device_lifecycle_mgmt/views.py
+++ b/nautobot_device_lifecycle_mgmt/views.py
@@ -719,7 +719,9 @@ class ValidatedSoftwareInventoryItemReportView(generic.ObjectListView):
     table = InventoryItemSoftwareValidationResultTable
     template_name = "nautobot_device_lifecycle_mgmt/validatedsoftware_inventoryitem_report.html"
     queryset = (
-        InventoryItemSoftwareValidationResult.objects.values("inventory_item__part_id", "inventory_item__pk")
+        InventoryItemSoftwareValidationResult.objects.values(
+            "inventory_item__part_id", "inventory_item__name", "inventory_item__pk", "inventory_item__device__name"
+        )
         .distinct()
         .annotate(
             total=Count("inventory_item__part_id"),
@@ -828,7 +830,14 @@ class ValidatedSoftwareInventoryItemReportView(generic.ObjectListView):
         csv_data.append(",".join([]))
 
         qs = self.queryset.values(
-            "inventory_item__part_id", "total", "valid", "invalid", "no_software", "valid_percent"
+            "inventory_item__part_id",
+            "inventory_item__name",
+            "inventory_item__device__name",
+            "total",
+            "valid",
+            "invalid",
+            "no_software",
+            "valid_percent",
         )
         csv_data.append(
             ",".join(


### PR DESCRIPTION
Currently there really isn't a clear view of the inventory items on the summary page and list page. I want to give more clarity by adding in device and inventory item name to help identify. Fixing API name and making columns sortable.

### Before:

Summary Page

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/923138f0-a701-4a61-92b4-92ec16a62824)

List Page

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/ac7f4af6-0a61-48ce-aba1-8d4107372bae)

API

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/21af6d8f-1b45-4605-b77d-d125cc71333b)

### After:

Summary page

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/c5704c29-1b03-495d-b895-7dec0a7342ea)

List page

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/c1ac6715-8ffe-4eb1-bafe-85aa8f0fdb97)

API

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/52daf55a-bb48-4479-abd4-94c339711f12)
