### PR TITLE
Fix column headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         nautobot-version: ["1.4.10", "stable"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
         nautobot-version: ["1.4.10"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         nautobot-version: ["1.4.10", "stable"]
     runs-on: "ubuntu-20.04"
     env:

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -319,15 +319,17 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         orderable=True,
         accessor="inventory_item__part_id",
     )
-    part_name = tables.TemplateColumn(
-        template_code="{{ record.inventory_item__name }}",
-        orderable=True,
+    item_name = tables.TemplateColumn(
+        template_code="""<a href='/dcim/inventory-items/{{ record.inventory_item__pk }}'>{{ record.inventory_item__name }}</a>""",
+        verbose_name="Item Name",
         accessor="inventory_item__name",
+        orderable=True,
     )
     device = tables.TemplateColumn(
         template_code="{{ record.inventory_item__device__name }}",
         orderable=True,
         accessor="inventory_item__device__name",
+        verbose_name= "Device",
     )
     total = tables.TemplateColumn(
         template_code='<a href="/plugins/nautobot-device-lifecycle-mgmt/inventory-item-validated-software-result/'
@@ -356,10 +358,10 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         """Metaclass attributes of InventoryItemSoftwareValidationResultTable."""
 
         model = InventoryItemSoftwareValidationResult
-        fields = ["part_id", "part_name", "device", "total", "valid", "invalid", "no_software", "valid_percent"]
+        fields = ["part_id", "item_name", "device", "total", "valid", "invalid", "no_software", "valid_percent"]
         default_columns = [
             "part_id",
-            "part_name",
+            "item_name",
             "device",
             "total",
             "valid",
@@ -378,11 +380,12 @@ class InventoryItemSoftwareValidationResultListTable(BaseTable):
         verbose_name="Part ID",
         default="Please assign Part ID value to Inventory Item",
     )
-    part_name = tables.TemplateColumn(
+    item_name = tables.TemplateColumn(
         template_code="""<a href='/dcim/inventory-items/{{ record.inventory_item.pk }}'>
                         {{ record.inventory_item.name }}</a>""",
-        verbose_name="Part Name",
+        verbose_name="Item Name",
         accessor="inventory_item__name",
+        orderable=True,
     )
     device_name = tables.Column(accessor="inventory_item__device__name", verbose_name="Device")
     software = tables.Column(accessor="software", verbose_name="Current Software", linkify=True)
@@ -404,10 +407,10 @@ class InventoryItemSoftwareValidationResultListTable(BaseTable):
         """Metaclass attributes of InventoryItemSoftwareValidationResultTable."""
 
         model = InventoryItemSoftwareValidationResult
-        fields = ["part_id", "part_name", "device_name", "software", "valid", "last_run", "run_type", "valid_software"]
+        fields = ["part_id", "item_name", "device_name", "software", "valid", "last_run", "run_type", "valid_software"]
         default_columns = [
             "part_id",
-            "part_name",
+            "item_name",
             "device_name",
             "software",
             "valid",

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -329,7 +329,7 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         template_code="{{ record.inventory_item__device__name }}",
         orderable=True,
         accessor="inventory_item__device__name",
-        verbose_name= "Device",
+        verbose_name="Device",
     )
     total = tables.TemplateColumn(
         template_code='<a href="/plugins/nautobot-device-lifecycle-mgmt/inventory-item-validated-software-result/'

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -325,7 +325,7 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         accessor="inventory_item__name",
         orderable=True,
     )
-    device =  tables.TemplateColumn(
+    device = tables.TemplateColumn(
         template_code="""<a href='/dcim/devices/{{ record.inventory_item__device__pk }}'>
                         {{ record.inventory_item__device__name }}</a>""",
         orderable=True,
@@ -388,7 +388,7 @@ class InventoryItemSoftwareValidationResultListTable(BaseTable):
         accessor="inventory_item__name",
         orderable=True,
     )
-    device_name =  tables.TemplateColumn(
+    device_name = tables.TemplateColumn(
         template_code="""<a href='/dcim/devices/{{ record.inventory_item.device.pk }}'>
                         {{ record.inventory_item.device.name }}</a>""",
         orderable=True,

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -325,10 +325,11 @@ class InventoryItemSoftwareValidationResultTable(BaseTable):
         accessor="inventory_item__name",
         orderable=True,
     )
-    device = tables.TemplateColumn(
-        template_code="{{ record.inventory_item__device__name }}",
+    device =  tables.TemplateColumn(
+        template_code="""<a href='/dcim/devices/{{ record.inventory_item__device__pk }}'>
+                        {{ record.inventory_item__device__name }}</a>""",
         orderable=True,
-        accessor="inventory_item__device__name",
+        accessor="inventory_item__device__pk",
         verbose_name="Device",
     )
     total = tables.TemplateColumn(
@@ -387,7 +388,13 @@ class InventoryItemSoftwareValidationResultListTable(BaseTable):
         accessor="inventory_item__name",
         orderable=True,
     )
-    device_name = tables.Column(accessor="inventory_item__device__name", verbose_name="Device")
+    device_name =  tables.TemplateColumn(
+        template_code="""<a href='/dcim/devices/{{ record.inventory_item.device.pk }}'>
+                        {{ record.inventory_item.device.name }}</a>""",
+        orderable=True,
+        accessor="inventory_item__device__pk",
+        verbose_name="Device",
+    )
     software = tables.Column(accessor="software", verbose_name="Current Software", linkify=True)
     valid = tables.Column(accessor="is_validated", verbose_name="Valid")
     last_run = tables.Column(accessor="last_run", verbose_name="Last Run")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.8,<3.11"
 pycountry = "^22.3.5"
 matplotlib = "^3.3.4"
 nautobot = "^1.4.0"


### PR DESCRIPTION
This fixes column headers on Inventory item summary page and makes part names clickable/sortable.

![image](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/76115401/ccd6e810-fea6-4e59-8f07-1c3bfa2cd7b0)
