### PR TITLE
Fix currency filter and country filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
         nautobot-version: ["1.4.10", "stable"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
         nautobot-version: ["1.4.10", "stable"]
     runs-on: "ubuntu-20.04"
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         nautobot-version: ["1.4.10", "stable"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         nautobot-version: ["1.4.10", "stable"]
     runs-on: "ubuntu-20.04"
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10","3.11"]
         nautobot-version: ["1.4.10", "stable"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         nautobot-version: ["1.4.10", "stable"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
         nautobot-version: ["1.4.10"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         nautobot-version: ["1.4.10", "stable"]
     runs-on: "ubuntu-20.04"
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10","3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
         nautobot-version: ["1.4.10", "stable"]
     env:
       INVOKE_NAUTOBOT_DEVICE_LIFECYCLE_MGMT_PYTHON_VER: "${{ matrix.python-version }}"

--- a/nautobot_device_lifecycle_mgmt/filters.py
+++ b/nautobot_device_lifecycle_mgmt/filters.py
@@ -693,8 +693,6 @@ class ContractLCMFilterSet(NautobotFilterSet):
     end__gte = django_filters.DateFilter(field_name="end", lookup_expr="gte")
     end__lte = django_filters.DateFilter(field_name="end", lookup_expr="lte")
 
-    contract_type = django_filters.CharFilter(field_name="contract_type", label="Contract Type")
-
     class Meta:
         """Meta attributes for filter."""
 

--- a/nautobot_device_lifecycle_mgmt/filters.py
+++ b/nautobot_device_lifecycle_mgmt/filters.py
@@ -1,6 +1,5 @@
 """Filtering implementation for the Lifecycle Management plugin."""
 import datetime
-from locale import currency
 
 import django_filters
 from django.db.models import Q

--- a/nautobot_device_lifecycle_mgmt/filters.py
+++ b/nautobot_device_lifecycle_mgmt/filters.py
@@ -1,5 +1,6 @@
 """Filtering implementation for the Lifecycle Management plugin."""
 import datetime
+from locale import currency
 
 import django_filters
 from django.db.models import Q
@@ -693,6 +694,8 @@ class ContractLCMFilterSet(NautobotFilterSet):
     end__gte = django_filters.DateFilter(field_name="end", lookup_expr="gte")
     end__lte = django_filters.DateFilter(field_name="end", lookup_expr="lte")
 
+    contract_type = django_filters.CharFilter(field_name="contract_type", label="Contract Type")
+
     class Meta:
         """Meta attributes for filter."""
 
@@ -707,6 +710,7 @@ class ContractLCMFilterSet(NautobotFilterSet):
             "support_level",
             "contract_type",
             "expired",
+            "currency",
         ]
 
     def search(self, queryset, name, value):  # pylint: disable=unused-argument, no-self-use

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -920,7 +920,7 @@ class ProviderLCMFilterForm(BootstrapMixin, forms.ModelForm):
     q = forms.CharField(required=False, label="Search")
     name = forms.CharField(required=False)
     country = forms.MultipleChoiceField(
-        required=False, choices=add_blank_choice(CountryCodes.CHOICES), widget=StaticSelect2Multiple()
+        required=False, choices=CountryCodes.CHOICES, widget=StaticSelect2Multiple()
     )
 
     class Meta:

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -919,7 +919,9 @@ class ProviderLCMFilterForm(BootstrapMixin, forms.ModelForm):
 
     q = forms.CharField(required=False, label="Search")
     name = forms.CharField(required=False)
-    country = forms.MultipleChoiceField(required=False, choices=CountryCodes.CHOICES, widget=StaticSelect2Multiple())
+    country = forms.MultipleChoiceField(
+        required=False, choices=add_blank_choice(CountryCodes.CHOICES), widget=StaticSelect2Multiple()
+    )
 
     class Meta:
         """Meta attributes for the ProviderLCMFilterForm class."""

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -915,11 +915,6 @@ class ProviderLCMFilterForm(BootstrapMixin, forms.ModelForm):
 
     q = forms.CharField(required=False, label="Search")
     name = forms.CharField(required=False)
-    # country = forms.ChoiceField(
-    #     widget=StaticSelect2,
-    #     required=False,
-    #     choices=add_blank_choice(CountryCodes.CHOICES),
-    # )
     country = forms.MultipleChoiceField(required=False, choices=CountryCodes.CHOICES, widget=StaticSelect2Multiple())
 
     class Meta:

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -817,8 +817,12 @@ class ContractLCMFilterForm(BootstrapMixin, forms.ModelForm):
 
     q = forms.CharField(required=False, label="Search")
     provider = forms.ModelMultipleChoiceField(required=False, queryset=ProviderLCM.objects.all(), to_field_name="pk")
-    currency = forms.MultipleChoiceField(required=False, choices=CurrencyChoices.CHOICES, widget=StaticSelect2Multiple())
-    contract_type = forms.ChoiceField(required=False, widget=StaticSelect2, choices=add_blank_choice(ContractTypeChoices.CHOICES))
+    currency = forms.MultipleChoiceField(
+        required=False, choices=CurrencyChoices.CHOICES, widget=StaticSelect2Multiple()
+    )
+    contract_type = forms.ChoiceField(
+        required=False, widget=StaticSelect2, choices=add_blank_choice(ContractTypeChoices.CHOICES)
+    )
     name = forms.CharField(required=False)
 
     class Meta:

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -26,6 +26,7 @@ from nautobot.utilities.forms import (
     StaticSelect2,
     TagFilterField,
     add_blank_choice,
+    StaticSelect2Multiple,
 )
 
 from nautobot_device_lifecycle_mgmt.choices import (
@@ -816,7 +817,8 @@ class ContractLCMFilterForm(BootstrapMixin, forms.ModelForm):
 
     q = forms.CharField(required=False, label="Search")
     provider = forms.ModelMultipleChoiceField(required=False, queryset=ProviderLCM.objects.all(), to_field_name="pk")
-    currency = forms.ChoiceField(required=False, widget=StaticSelect2, choices=CurrencyChoices.CHOICES)
+    currency = forms.MultipleChoiceField(required=False, choices=CurrencyChoices.CHOICES, widget=StaticSelect2Multiple())
+    contract_type = forms.ChoiceField(required=False, widget=StaticSelect2, choices=add_blank_choice(ContractTypeChoices.CHOICES))
     name = forms.CharField(required=False)
 
     class Meta:
@@ -913,11 +915,12 @@ class ProviderLCMFilterForm(BootstrapMixin, forms.ModelForm):
 
     q = forms.CharField(required=False, label="Search")
     name = forms.CharField(required=False)
-    country = forms.ChoiceField(
-        widget=StaticSelect2,
-        required=False,
-        choices=add_blank_choice(CountryCodes.CHOICES),
-    )
+    # country = forms.ChoiceField(
+    #     widget=StaticSelect2,
+    #     required=False,
+    #     choices=add_blank_choice(CountryCodes.CHOICES),
+    # )
+    country = forms.MultipleChoiceField(required=False, choices=CountryCodes.CHOICES, widget=StaticSelect2Multiple())
 
     class Meta:
         """Meta attributes for the ProviderLCMFilterForm class."""

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -919,9 +919,7 @@ class ProviderLCMFilterForm(BootstrapMixin, forms.ModelForm):
 
     q = forms.CharField(required=False, label="Search")
     name = forms.CharField(required=False)
-    country = forms.MultipleChoiceField(
-        required=False, choices=CountryCodes.CHOICES, widget=StaticSelect2Multiple()
-    )
+    country = forms.MultipleChoiceField(required=False, choices=CountryCodes.CHOICES, widget=StaticSelect2Multiple())
 
     class Meta:
         """Meta attributes for the ProviderLCMFilterForm class."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<3.10"
 pycountry = "^22.3.5"
 matplotlib = "^3.3.4"
 nautobot = "^1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8,<3.12"
 pycountry = "^22.3.5"
 matplotlib = "^3.3.4"
 nautobot = "^1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.10"
+python = ">=3.8,<3.11"
 pycountry = "^22.3.5"
 matplotlib = "^3.3.4"
 nautobot = "^1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 pycountry = "^22.3.5"
 matplotlib = "^3.3.4"
 nautobot = "^1.4.0"


### PR DESCRIPTION
This will enable the multi selection for filtering in:

`currency` in the Contracts view
`country` in the Vendors view

Before you were only able to filter on 1 selection in regards to currency and country. Now you can select multiple and it will filter out.

This will close #187 