### PR TITLE
added ipython to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ matplotlib = "^3.3.4"
 nautobot = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
+ipython = "*"
 invoke = "*"
 black = "*"
 bandit = "*"


### PR DESCRIPTION
When attempting to run shell-plus, got this error:




```
timothyfiola@ipxxxxxx nautobot-plugin-device-lifecycle-mgmt % invoke shell-plus       
Running docker-compose command "ps --services --filter status=running"
Running docker-compose command "run --entrypoint 'nautobot-server shell_plus' nautobot"
[+] Running 2/0
 ⠿ Container nautobot_device_lifecycle_mgmt-redis-1  Running                                                                                                                                                                                                          0.0s
 ⠿ Container nautobot_device_lifecycle_mgmt-db-1     Running                                                                                                                                                                                                          0.0s
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django_extensions/management/commands/shell_plus.py", line 399, in get_ipython
    from IPython import start_ipython
ModuleNotFoundError: No module named 'IPython'

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django_extensions/management/commands/shell_plus.py", line 399, in get_ipython
    from IPython import start_ipython
ModuleNotFoundError: No module named 'IPython'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django_extensions/management/commands/shell_plus.py", line 413, in get_ipython
    from IPython.Shell import IPShell
ModuleNotFoundError: No module named 'IPython'

CommandError: Could not load shell runner: 'IPython'.
timothyfiola@ipxxxxxx nautobot-plugin-device-lifecycle-mgmt % 
```

Once I added this fix to my local instance, shell-plus loaded