### PR TITLE
Fix 2.0 migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [v2.0.2] - 2023-11-06
+
+Note: This release fixes an issue with upgrading this plugin from 1.x version to 2.x versions.
+
+### Fixed
+- [#250](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/pull/250) - Fix issue with migrations in 2.0.1 causing issues with upgrading plugin from 1.x versions.
+
 
 ## [v2.0.1] - 2023-10-31
 Note: This release fixes an issue with clean installations of this plugin on Nautobot 2.0.X environments.

--- a/docs/admin/release_notes/version_2.0.md
+++ b/docs/admin/release_notes/version_2.0.md
@@ -6,6 +6,14 @@ This document describes all new features and changes in the release `2.0`. The f
 
 This release adds support for [Nautobot v2.0.0](https://github.com/nautobot/nautobot/releases/tag/v2.0.0).
 
+## [v2.0.2] - 2023-11-06
+
+Note: This release fixes an issue with upgrading this plugin from 1.x version to 2.x versions.
+
+### Fixed
+- [#250](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/pull/250) - Fix issue with migrations in 2.0.1 causing issues with upgrading plugin from 1.x versions.
+
+
 ## [v2.0.1] - 2023-10-31
 Note: This release fixes an issue with clean installations of this plugin on Nautobot 2.0.X environments.
 

--- a/nautobot_device_lifecycle_mgmt/migrations/0016_role_migration_cleanup.py
+++ b/nautobot_device_lifecycle_mgmt/migrations/0016_role_migration_cleanup.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
         if self.nautobot_run_before:
             recorder = migrations.recorder.MigrationRecorder(connection)
             applied_migrations = recorder.applied_migrations()
-            if ("nautobot_device_onboarding", "0004_validated_software_m2m") in applied_migrations:
+            if ("nautobot_device_lifecycle_mgmt", "0004_validated_software_m2m") in applied_migrations:
                 for migration in self.nautobot_run_before:
                     if migration not in applied_migrations:
                         self.run_before.append(migration)


### PR DESCRIPTION
Fixes issue with one of the migrations in 2.0.1 referencing wrong app, causing migrations to fail when installing 2.0.1 in Nautobot 2.0 that was upgraded from Nautobot 1.x with an older version of DLM installed.

Addresses #249 