### PR TITLE
NAPPS-358 Fixed large traceback being generated in the logs when a 404 was raised.

### DIFF
--- a/changes/465.fixed
+++ b/changes/465.fixed
@@ -1,0 +1,1 @@
+Fixed large traceback being generated in the logs when a 404 was raised.

--- a/nautobot_device_lifecycle_mgmt/banner.py
+++ b/nautobot_device_lifecycle_mgmt/banner.py
@@ -1,6 +1,6 @@
 """Banners for the Device Lifecycle Management app."""
 
-from django.urls import resolve, reverse
+from django.urls import NoReverseMatch, Resolver404, resolve, reverse
 from django.utils.html import format_html
 from nautobot.apps.ui import Banner, BannerClassChoices
 from nautobot.extras.models import Job
@@ -23,7 +23,10 @@ def all_models_migrated_to_core():
 
 def models_migrated_to_core_banner(context):
     """Emit a banner on DLM views if models are not migrated to core."""
-    app_name = resolve(context.request.path).app_name
+    try:
+        app_name = resolve(context.request.path).app_name
+    except (AttributeError, NoReverseMatch, Resolver404):
+        return None
     if app_name != "plugins:nautobot_device_lifecycle_mgmt":
         return None
     if all_models_migrated_to_core():


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Lifecycle Management! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #465 

## What's Changed

### Before (3708 bytes)

```
nautobot-1  | 22:13:54.098 ERROR   nautobot.extras.templatetags.plugins : Plugin banner function <function models_migrated_to_core_banner at 0x7f1e70724d60> raised an exception: {'tried': [[<URLPattern '' [name='home']>], [<URLPattern 'search/' [name='search']>], [<URLPattern 'login/' [name='login']>], [<URLPattern 'logout/' [name='logout']>], [<URLResolver <module 'nautobot.circuits.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/circuits/urls.py'> (circuits:circuits) 'circuits/'>], [<URLResolver <module 'nautobot.cloud.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/cloud/urls.py'> (cloud:cloud) 'cloud/'>], [<URLResolver <module 'nautobot.dcim.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/dcim/urls.py'> (dcim:dcim) 'dcim/'>], [<URLResolver <module 'nautobot.extras.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/extras/urls.py'> (extras:extras) 'extras/'>], [<URLResolver <module 'nautobot.ipam.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/ipam/urls.py'> (ipam:ipam) 'ipam/'>], [<URLResolver <module 'nautobot.tenancy.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/tenancy/urls.py'> (tenancy:tenancy) 'tenancy/'>], [<URLResolver <module 'nautobot.users.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/users/urls.py'> (user:user) 'user/'>], [<URLResolver <module 'nautobot.users.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/users/urls.py'> (user:users) 'users/'>], [<URLResolver <module 'nautobot.virtualization.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/virtualization/urls.py'> (virtualization:virtualization) 'virtualization/'>], [<URLResolver <module 'nautobot.core.api.urls' from '/usr/local/lib/python3.11/site-packages/nautobot/core/api/urls.py'> (None:None) 'api/'>], [<URLPattern 'graphql/' [name='graphql']>], [<URLPattern 'media/<path:path>'>], [<URLResolver <URLPattern list> (admin:admin) 'admin/'>], [<URLPattern 'media-failure/' [name='media_failure']>], [<URLResolver <URLPattern list> (apps:apps) 'apps/'>], [<URLResolver <URLPattern list> (plugins:plugins) 'plugins/'>], [<URLResolver [] (None:None) 'admin/plugins/'>], [<URLResolver <module 'social_django.urls' from '/usr/local/lib/python3.11/site-packages/social_django/urls.py'> (social:social) ''>, <URLPattern 'login/<str:backend>/' [name='begin']>], [<URLResolver <module 'social_django.urls' from '/usr/local/lib/python3.11/site-packages/social_django/urls.py'> (social:social) ''>, <URLPattern 'complete/<str:backend>/' [name='complete']>], [<URLResolver <module 'social_django.urls' from '/usr/local/lib/python3.11/site-packages/social_django/urls.py'> (social:social) ''>, <URLPattern 'disconnect/<str:backend>/' [name='disconnect']>], [<URLResolver <module 'social_django.urls' from '/usr/local/lib/python3.11/site-packages/social_django/urls.py'> (social:social) ''>, <URLPattern 'disconnect/<str:backend>/<int:association_id>/' [name='disconnect_individual']>], [<URLResolver <module 'health_check.urls' from '/usr/local/lib/python3.11/site-packages/health_check/urls.py'> (health_check:health_check) 'health/'>], [<URLPattern 'files/download/' [name='db_file_storage.download_file']>], [<URLPattern 'worker-status/' [name='worker_status']>], [<URLPattern 'template.css' [name='template_css']>], [<URLPattern 'metrics/' [name='metrics']>], [<URLResolver <module 'silk.urls' from '/usr/local/lib/python3.11/site-packages/silk/urls.py'> (silk:silk) 'silk/'>]], 'path': 'swagger/swagger-ui.html'}
nautobot-1  | 22:13:54.120 WARNING django.request : Not Found: /swagger/swagger-ui.html
nautobot-1  | 22:13:54.121 WARNING django.server : "GET /swagger/swagger-ui.html HTTP/1.1" 404 217700
```

### After (189 bytes)

```
nautobot-1  | 22:20:36.560 WARNING django.request : Not Found: /swagger/swagger-ui.html
nautobot-1  | 22:20:36.560 WARNING django.server : "GET /swagger/swagger-ui.html HTTP/1.1" 404 217700
```


<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
