### PR TITLE
allows cloning of validated software objects

### DIFF
--- a/changes/512.changed
+++ b/changes/512.changed
@@ -1,0 +1,1 @@
+Allowed cloning of validated software objects.

--- a/nautobot_device_lifecycle_mgmt/models.py
+++ b/nautobot_device_lifecycle_mgmt/models.py
@@ -307,6 +307,18 @@ class ValidatedSoftwareLCM(PrimaryModel):
         ordering = ("software", "preferred", "start")
         unique_together = ("software", "start", "end")
 
+    clone_fields = (
+        "software",
+        "devices",
+        "device_types",
+        "device_roles",
+        "inventory_items",
+        "object_tags",
+        "start",
+        "end",
+        "preferred",
+    )
+
     def __str__(self):
         """String representation of ValidatedSoftwareLCM."""
         msg = f"{self.software} - Valid since: {self.start}"


### PR DESCRIPTION
# Closes: DNE

## What's Changed

Allows cloning of validated software objects by adding cloned_fields.

<img width="275" height="168" alt="Bildschirmfoto 2025-11-06 um 14 43 56" src="https://github.com/user-attachments/assets/d26be486-cdd0-4b92-98cf-673b9b2d4aa5" />

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
