### PR TITLE
Allow cloning of validated software - next3.0

### DIFF
--- a/changes/512.changed
+++ b/changes/512.changed
@@ -1,0 +1,1 @@
+Allowed cloning of validated software objects.

--- a/nautobot_device_lifecycle_mgmt/models.py
+++ b/nautobot_device_lifecycle_mgmt/models.py
@@ -312,6 +312,18 @@ class ValidatedSoftwareLCM(PrimaryModel):
         ordering = ("software", "preferred", "start")
         unique_together = ("software", "start", "end")
 
+    clone_fields = (
+        "software",
+        "devices",
+        "device_types",
+        "device_roles",
+        "inventory_items",
+        "object_tags",
+        "start",
+        "end",
+        "preferred",
+    )
+
     def __str__(self):
         """String representation of ValidatedSoftwareLCM."""
         return f"{self.software.version} - Valid since: {self.start}"


### PR DESCRIPTION
Allow cloning of validated software. Clone of the https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/512/ PR for next-3.0.