### PR TITLE
Release v3.2.1

### DIFF
--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/490.housekeeping
+++ b/changes/490.housekeeping
@@ -1,1 +1,0 @@
-Refactored DeviceHardwareNoticeResult, DeviceSoftwareValidationResult, InventoryItemSoftwareValidationResult model related UI views to use `NautobotUIViewSet`.

--- a/changes/494.housekeeping
+++ b/changes/494.housekeeping
@@ -1,1 +1,0 @@
-Refactored HardwareLCM,ValidatedSoftwareLCM,ContractLCM,ProviderLCM,CVELCM,VulnerabilityLCM model related UI views to use `UI component framework`.

--- a/changes/498.housekeeping
+++ b/changes/498.housekeeping
@@ -1,3 +1,0 @@
-Updated generate_dlm_test_data management command for DLM v3.
-Added --flush argument to generate_dlm_test_data management command.
-Added change logging to generate_dlm_test_data management command.

--- a/changes/506.housekeeping
+++ b/changes/506.housekeeping
@@ -1,1 +1,0 @@
-Update any call to `get_extra_context` to call super of the method first.

--- a/changes/512.changed
+++ b/changes/512.changed
@@ -1,1 +1,0 @@
-Allowed cloning of validated software objects.

--- a/changes/528.fixed
+++ b/changes/528.fixed
@@ -1,1 +1,0 @@
-Fixed filter and filter test bugs.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -1,4 +1,3 @@
-
 # v3.2 Release Notes
 
 This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -12,6 +11,29 @@ Device Lifecycle Management App version 3.2.0 adds support for ArubaOS and PanOS
 
 !!! warning
     This release drops support for Python 3.9. Python 3.10 is now the minimum required version.
+
+<!-- towncrier release notes start -->
+## [v3.2.1 (2025-12-08)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.1)
+
+### Changed
+
+- [#512](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/512) - Allowed cloning of validated software objects.
+
+### Fixed
+
+- [#528](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/528) - Fixed filter and filter test bugs.
+
+### Housekeeping
+
+- [#490](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/490) - Refactored DeviceHardwareNoticeResult, DeviceSoftwareValidationResult, InventoryItemSoftwareValidationResult model related UI views to use `NautobotUIViewSet`.
+- [#494](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/494) - Refactored HardwareLCM,ValidatedSoftwareLCM,ContractLCM,ProviderLCM,CVELCM,VulnerabilityLCM model related UI views to use `UI component framework`.
+- [#498](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/498) - Updated generate_dlm_test_data management command for DLM v3.
+- [#498](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/498) - Added --flush argument to generate_dlm_test_data management command.
+- [#498](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/498) - Added change logging to generate_dlm_test_data management command.
+- [#506](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/506) - Update any call to `get_extra_context` to call super of the method first.
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.
 
 ## [v3.2.0 (2025-10-24)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "3.2.1a0"
+version = "3.2.1"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"
@@ -169,7 +169,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_device_lifecycle_mgmt"
 directory = "changes"
-filename = "docs/admin/release_notes/version_X.Y.md"
+filename = "docs/admin/release_notes/version_3.2.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/{issue})"


### PR DESCRIPTION
## [v3.2.1 (2025-12-08)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.1)

### Changed

- [#512](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/512) - Allowed cloning of validated software objects.

### Fixed

- [#528](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/528) - Fixed filter and filter test bugs.

### Housekeeping

- [#490](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/490) - Refactored DeviceHardwareNoticeResult, DeviceSoftwareValidationResult, InventoryItemSoftwareValidationResult model related UI views to use `NautobotUIViewSet`.
- [#494](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/494) - Refactored HardwareLCM,ValidatedSoftwareLCM,ContractLCM,ProviderLCM,CVELCM,VulnerabilityLCM model related UI views to use `UI component framework`.
- [#498](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/498) - Updated generate_dlm_test_data management command for DLM v3.
- [#498](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/498) - Added --flush argument to generate_dlm_test_data management command.
- [#498](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/498) - Added change logging to generate_dlm_test_data management command.
- [#506](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/506) - Update any call to `get_extra_context` to call super of the method first.
- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.