### PR TITLE
Nautobot UI: replace Reference column with Device Type in Name for Ha…

### DIFF
--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -40,19 +40,13 @@ class HardwareLCMTable(BaseTable):
     """Table for list view."""
 
     pk = ToggleColumn()
-    name = tables.LinkColumn(
-        "plugins:nautobot_device_lifecycle_mgmt:hardwarelcm",
-        text=lambda record: record,
-        args=[A("pk")],
-        orderable=False,
-    )
-    reference_item = tables.TemplateColumn(
+    name = tables.TemplateColumn(
         template_code="""{% if record.device_type %}
                     <a href="{% url 'dcim:devicetype' pk=record.device_type.pk %}">{{ record.device_type }}</a>
                     {% elif record.inventory_item %}
                     {{ record.inventory_item }}
                     {% endif %}""",
-        verbose_name="Reference",
+        verbose_name="Name",
         orderable=False,
     )
     documentation_url = tables.TemplateColumn(
@@ -74,7 +68,6 @@ class HardwareLCMTable(BaseTable):
         fields = (
             "pk",
             "name",
-            "reference_item",
             "release_date",
             "end_of_sale",
             "end_of_support",


### PR DESCRIPTION
# Closes: N/A (UI improvement)

## What's Changed

### Hardware list UI simplification

This change improves the Hardware Lifecycle Management list view by simplifying how device information is presented:

- The content previously displayed in the *Reference* column has been moved into the *Name* column.
- The *Reference* column has been removed from the Hardware list.
- The *Name* column now displays the related Device Type (or Inventory Item when applicable), providing a clearer and more intuitive primary identifier.

This is a UI-only change and does not affect models, APIs, or stored data.

---

## To Do

- [x] Explanation of Change(s)
- [ ] Added change log fragment(s)
- [] Attached Screenshots (Before / After)
- [ ] Unit, Integration Tests (not required for UI-only change)
- [ ] Documentation Updates (not required)
- [ ] Outline Remaining Work, Constraints from Design