### PR TITLE
Release v3.2.2

### DIFF
--- a/changes/544.housekeeping
+++ b/changes/544.housekeeping
@@ -1,1 +1,0 @@
-Updated pycountry to 24.6.1 to eliminate deprecated pkg_resources API usage.

--- a/changes/547.housekeeping
+++ b/changes/547.housekeeping
@@ -1,1 +1,0 @@
-Updated django-debug-toolbar to 4.4.0 to fix import errors.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -13,6 +13,15 @@ Device Lifecycle Management App version 3.2.0 adds support for ArubaOS and PanOS
     This release drops support for Python 3.9. Python 3.10 is now the minimum required version.
 
 <!-- towncrier release notes start -->
+
+
+## [v3.2.2 (2026-01-23)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.2)
+
+### Housekeeping
+
+- [#544](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/544) - Updated pycountry to 24.6.1 to eliminate deprecated pkg_resources API usage.
+- [#547](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/547) - Updated django-debug-toolbar to 4.4.0 to fix import errors.
+
 ## [v3.2.1 (2025-12-08)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.1)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "3.2.1"
+version = "3.2.2"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v3.2.2 (2026-01-23)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.2)

### Housekeeping

- [#544](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/544) - Updated pycountry to 24.6.1 to eliminate deprecated pkg_resources API usage.
- [#547](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/547) - Updated django-debug-toolbar to 4.4.0 to fix import errors.