### PR TITLE
Fixed AttributeError on missing software related field

### DIFF
--- a/changes/554.fixed
+++ b/changes/554.fixed
@@ -1,0 +1,1 @@
+Fixed an issue rendering Validated Software in the UI before running the job to migrate to the core models.

--- a/nautobot_device_lifecycle_mgmt/models.py
+++ b/nautobot_device_lifecycle_mgmt/models.py
@@ -326,6 +326,8 @@ class ValidatedSoftwareLCM(PrimaryModel):
 
     def __str__(self):
         """String representation of ValidatedSoftwareLCM."""
+        if not self.software:
+            return str(self.pk)
         return f"{self.software.version} - Valid since: {self.start}"
 
     @property


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Lifecycle Management! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #554

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
In DLM v3, we introduced a job to migrate all deprecated models to the applicable Nautobot core models. In certain scenarios (e.g., if an environment jumps straight from DLM v2 to v4) when this migration job has not been run yet, it can cause an AttributeError when trying to render a model that is attempting to access an attribute of a related software field.

This PR simply uses the `pk` field as a stopgap while the `software` field is null in order to render the object's `__str__` method.

In order to replicate and verify this fix I performed the following actions:
- Checked out tag v2.2.1
- Updated Postgres image to v17 to match future versions
- Created a Software object
- Created ValidatedSoftware and Vulnerability objects linked to that software
  - <img width="520" height="279" alt="Screenshot 2026-02-10 at 4 00 37 PM" src="https://github.com/user-attachments/assets/400822b0-35a6-4071-a24f-fbdea3859ebd" />
- Checked out ltm-2.4 branch and let migrations run
  - This step was only needed because of some constance changes that were throwing errors when jumping straight from Nautobot 2.3.1 to 3.0.0
- Checked out develop branch and let migrations run
- Patched ValidatedSoftware to use pk if software was null
  - <img width="578" height="255" alt="Screenshot 2026-02-10 at 4 17 27 PM" src="https://github.com/user-attachments/assets/5d2e6dbb-7df0-4e1b-9a17-3325d97850d2" />
- Enabled the migration job
- Ran the migration job
  - Disabled option "Dryrun"
  - Enabled option "Update Core to match DLM"
  - Enabled option "Remove dangling relationship associations"
  - <img width="569" height="343" alt="Screenshot 2026-02-10 at 4 32 55 PM" src="https://github.com/user-attachments/assets/8283160d-8f03-4a04-aaf9-af0c07947e1d" />

As you can see in the middle screenshot, it may not be pretty but at least it renders. Once the migration job was run it reverted back to its original `__str__` representation that better represents the pre-3.0 version.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example

NTC-5039