### PR TITLE
Release v3.2.3

### DIFF
--- a/changes/554.fixed
+++ b/changes/554.fixed
@@ -1,1 +1,0 @@
-Fixed an issue rendering Validated Software in the UI before running the job to migrate to the core models.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -15,6 +15,12 @@ Device Lifecycle Management App version 3.2.0 adds support for ArubaOS and PanOS
 <!-- towncrier release notes start -->
 
 
+## [v3.2.3 (2026-02-18)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.3)
+
+### Fixed
+
+- [#554](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/554) - Fixed an issue rendering Validated Software in the UI before running the job to migrate to the core models.
+
 ## [v3.2.2 (2026-01-23)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.2)
 
 ### Housekeeping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "3.2.2"
+version = "3.2.3"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v3.2.3 (2026-02-18)](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/releases/tag/v3.2.3)

### Fixed

- [#554](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/554) - Fixed an issue rendering Validated Software in the UI before running the job to migrate to the core models.