### PR TITLE
Add filter extensions for hardware and software end of * dates and cves

### DIFF
--- a/changes/576.added
+++ b/changes/576.added
@@ -1,0 +1,6 @@
+Added `nautobot_device_lifecycle_mgmt_hardware_end_of_sale` Device filter extension.
+Added `nautobot_device_lifecycle_mgmt_hardware_end_of_software_releases` Device filter extension.
+Added `nautobot_device_lifecycle_mgmt_hardware_end_of_security_patches` Device filter extension.
+Added `nautobot_device_lifecycle_mgmt_hardware_end_of_support` Device filter extension.
+Added `nautobot_device_lifecycle_mgmt_software_version_end_of_support_date` Device filter extension.
+Added `nautobot_device_lifecycle_mgmt_has_cves` Software Version filter extension.

--- a/nautobot_device_lifecycle_mgmt/filter_extensions.py
+++ b/nautobot_device_lifecycle_mgmt/filter_extensions.py
@@ -201,7 +201,7 @@ class SoftwareVersionFilterExtension(FilterExtension):  # pylint: disable=too-fe
     model = "dcim.softwareversion"
 
     filterset_fields = {
-        "nautobot_device_lifecycle_mgmt_has_corresponding_cves": RelatedMembershipBooleanFilter(
+        "nautobot_device_lifecycle_mgmt_has_cves": RelatedMembershipBooleanFilter(
             field_name="corresponding_cves",
             label="Has CVEs",
         ),

--- a/nautobot_device_lifecycle_mgmt/filter_extensions.py
+++ b/nautobot_device_lifecycle_mgmt/filter_extensions.py
@@ -1,7 +1,12 @@
 """Extensions to core filters."""
 
 from django_filters import BooleanFilter, ModelMultipleChoiceFilter
-from nautobot.apps.filters import FilterExtension, NaturalKeyOrPKMultipleChoiceFilter
+from nautobot.apps.filters import (
+    FilterExtension,
+    MultiValueDateFilter,
+    NaturalKeyOrPKMultipleChoiceFilter,
+    RelatedMembershipBooleanFilter,
+)
 from nautobot.apps.forms import DynamicModelMultipleChoiceField
 
 from nautobot_device_lifecycle_mgmt.models import ContractLCM, HardwareLCM, ValidatedSoftwareLCM
@@ -67,6 +72,26 @@ class DeviceFilterExtension(FilterExtension):
             field_name="device_type__hardwarelcm",
             queryset=HardwareLCM.objects.all(),
             label="Hardware Reports",
+        ),
+        "nautobot_device_lifecycle_mgmt_hardware_end_of_sale": MultiValueDateFilter(
+            field_name="device_type__hardwarelcm__end_of_sale",
+            label="Hardware End of Sale Date",
+        ),
+        "nautobot_device_lifecycle_mgmt_hardware_end_of_software_releases": MultiValueDateFilter(
+            field_name="device_type__hardwarelcm__end_of_sw_releases",
+            label="Hardware End of Software Releases Date",
+        ),
+        "nautobot_device_lifecycle_mgmt_hardware_end_of_security_patches": MultiValueDateFilter(
+            field_name="device_type__hardwarelcm__end_of_security_patches",
+            label="Hardware End of Security Patches Date",
+        ),
+        "nautobot_device_lifecycle_mgmt_hardware_end_of_support": MultiValueDateFilter(
+            field_name="device_type__hardwarelcm__end_of_support",
+            label="Hardware End of Support Date",
+        ),
+        "nautobot_device_lifecycle_mgmt_software_version_end_of_support_date": MultiValueDateFilter(
+            field_name="software_version__end_of_support_date",
+            label="Software End of Support Date",
         ),
     }
 
@@ -168,6 +193,22 @@ class TagFilterExtension(FilterExtension):
 
 
 #
+# SOFTWAREVERSION FILTER EXTENSION
+#
+class SoftwareVersionFilterExtension(FilterExtension):  # pylint: disable=too-few-public-methods
+    """Extends SoftwareVersion Filters."""
+
+    model = "dcim.softwareversion"
+
+    filterset_fields = {
+        "nautobot_device_lifecycle_mgmt_has_corresponding_cves": RelatedMembershipBooleanFilter(
+            field_name="corresponding_cves",
+            label="Has CVEs",
+        ),
+    }
+
+
+#
 # REGISTER ALL EXTENSIONS
 #
 filter_extensions = [
@@ -176,4 +217,5 @@ filter_extensions = [
     RoleFilterExtension,
     DeviceTypeFilterExtension,
     TagFilterExtension,
+    SoftwareVersionFilterExtension,
 ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Lifecycle Management! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: NAPPS-850

## What's Changed

- Added `nautobot_device_lifecycle_mgmt_hardware_end_of_sale` Device filter extension
- Added `nautobot_device_lifecycle_mgmt_hardware_end_of_software_releases` Device filter extension
- Added `nautobot_device_lifecycle_mgmt_hardware_end_of_security_patches` Device filter extension
- Added `nautobot_device_lifecycle_mgmt_hardware_end_of_support` Device filter extension
- Added `nautobot_device_lifecycle_mgmt_software_version_end_of_support_date` Device filter extension
- Added `nautobot_device_lifecycle_mgmt_has_cves` Software Version filter extension

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
