### PR TITLE
Fixed CVSS severity standardization

### DIFF
--- a/changes/+link.documentation
+++ b/changes/+link.documentation
@@ -1,0 +1,1 @@
+Fixed a link to the NIST CVE API website in the documentation.

--- a/changes/566.added
+++ b/changes/566.added
@@ -1,0 +1,1 @@
+Added a migration to standardize all existing CVE severities.

--- a/changes/566.fixed
+++ b/changes/566.fixed
@@ -1,0 +1,1 @@
+Fixed the NIST CVE Job to use standardized values for severity.

--- a/docs/user/cve_tracking.md
+++ b/docs/user/cve_tracking.md
@@ -88,7 +88,7 @@ An External Integration must be created and configured in order to use the NIST 
         - ``backoff``: The backoff factor for the retry attempts (default: 2).  This is the multiplier for the delay between retries.
 - A new Secrets Group object named ``NAUTOBOT DLM NIST SECRETS GROUP`` used for access to the NIST API Key from the External Integration.
 - A new Secret object named ``NAUTOBOT DLM NIST API KEY``.  This object is created for you during setup with minimum defaults.  The Secret name must be exactly as above, but you will need to configure the Secret to properly access the NIST API Key.
-    - To obtain your NIST API Key go [here]('https://nvd.nist.gov/developers/request-an-api-key').
+    - To obtain your NIST API Key go [here](https://nvd.nist.gov/developers/request-an-api-key).
     - This key will be made invalid if not used for a seven day period and a request for a new key will be necessary to use this function.
 
 NOTE: You may change the name of the External Integration or create your own using other configuration settings, but the SecretsGroup and Secret objects must be named as above.  The External Integration is selected when starting the Job run.

--- a/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
+++ b/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
@@ -19,7 +19,9 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
 from urllib3.util import Retry
 
+from nautobot_device_lifecycle_mgmt.choices import CVESeverityChoices
 from nautobot_device_lifecycle_mgmt.models import CVELCM, VulnerabilityLCM
+from nautobot_device_lifecycle_mgmt.utils import standardize_cvss_severity
 
 name = "CVE Tracking"  # pylint: disable=invalid-name
 
@@ -259,7 +261,7 @@ class NistCveSyncSoftware(Job):
                 last_modified_date=date.fromisoformat(info.get("modified_date", "1900-01-01")[0:10]),
                 link=info["url"],
                 cvss=info["cvss_base_score"],
-                severity=info["cvss_severity"],
+                severity=standardize_cvss_severity(info["cvss_severity"]),
                 cvss_v2=info["cvssv2_score"],
                 cvss_v3=info["cvssv3_score"],
                 comments="ENTRY CREATED BY NAUTOBOT NIST JOB",
@@ -349,21 +351,22 @@ class NistCveSyncSoftware(Job):
 
     @staticmethod
     def convert_v2_base_score_to_severity(score: float) -> str:
-        """Uses V2 Base Score to convert to Severity Value.
+        """Use V2 Base Score to convert to a ``CVESeverityChoices`` value.
 
         Args:
-            score (float): CVSS V2 Base Score
+            score (float): CVSS V2 Base Score.
 
         Returns:
-            str: Severity Value ["HIGH", "MEDIUM", "LOW", "UNDEFINED"]
+            str: A ``CVESeverityChoices`` value. Out-of-band scores return
+            ``CVESeverityChoices.NONE``.
         """
-        if 0.0 >= score <= 3.9:
-            return "LOW"
-        if 4.0 >= score <= 6.9:
-            return "MEDIUM"
-        if 7.0 >= score <= 10:
-            return "HIGH"
-        return "UNDEFINED"
+        if 0.0 <= score <= 3.9:
+            return CVESeverityChoices.LOW
+        if 4.0 <= score <= 6.9:
+            return CVESeverityChoices.MEDIUM
+        if 7.0 <= score <= 10.0:
+            return CVESeverityChoices.HIGH
+        return CVESeverityChoices.NONE
 
     def prep_cve_for_dlc(self, cve_json: dict) -> dict:  # pylint: disable=too-many-locals
         """Convert CVE info into a format compatible with the DLC model.
@@ -453,7 +456,7 @@ class NistCveSyncSoftware(Job):
         current_dlc_cve.last_modified_date = f"{updated_cve['modified_date'][0:10]}"
         current_dlc_cve.link = updated_cve["url"]
         current_dlc_cve.cvss = updated_cve["cvss_base_score"]
-        current_dlc_cve.severity = updated_cve["cvss_severity"].title()
+        current_dlc_cve.severity = standardize_cvss_severity(updated_cve["cvss_severity"])
         current_dlc_cve.cvss_v2 = updated_cve["cvssv2_score"]
         current_dlc_cve.cvss_v3 = updated_cve["cvssv3_score"]
 

--- a/nautobot_device_lifecycle_mgmt/migrations/0030_standardize_cve_severity.py
+++ b/nautobot_device_lifecycle_mgmt/migrations/0030_standardize_cve_severity.py
@@ -11,7 +11,7 @@ def _standardize(raw):
 
 
 def standardize_cve_severity(apps, schema_editor):
-    """Coerce CVELCM.severity values to CVESeverityChoices via standardize_cvss_severity."""
+    """Coerce CVELCM.severity values to CVESeverityChoices via _standardize."""
     CVELCM = apps.get_model("nautobot_device_lifecycle_mgmt", "CVELCM")
     for raw in CVELCM.objects.values_list("severity", flat=True).distinct():
         standardized = _standardize(raw)

--- a/nautobot_device_lifecycle_mgmt/migrations/0030_standardize_cve_severity.py
+++ b/nautobot_device_lifecycle_mgmt/migrations/0030_standardize_cve_severity.py
@@ -1,13 +1,20 @@
 from django.db import migrations
 
-from nautobot_device_lifecycle_mgmt.utils import standardize_cvss_severity
+_VALID_SEVERITIES = {"Critical", "High", "Medium", "Low", "None"}
+
+
+def _standardize(raw):
+    if not raw:
+        return "None"
+    candidate = raw.strip().title()
+    return candidate if candidate in _VALID_SEVERITIES else "None"
 
 
 def standardize_cve_severity(apps, schema_editor):
     """Coerce CVELCM.severity values to CVESeverityChoices via standardize_cvss_severity."""
     CVELCM = apps.get_model("nautobot_device_lifecycle_mgmt", "CVELCM")
     for raw in CVELCM.objects.values_list("severity", flat=True).distinct():
-        standardized = standardize_cvss_severity(raw)
+        standardized = _standardize(raw)
         if standardized != raw:
             CVELCM.objects.filter(severity=raw).update(severity=standardized)
 

--- a/nautobot_device_lifecycle_mgmt/migrations/0030_standardize_cve_severity.py
+++ b/nautobot_device_lifecycle_mgmt/migrations/0030_standardize_cve_severity.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+from nautobot_device_lifecycle_mgmt.utils import standardize_cvss_severity
+
+
+def standardize_cve_severity(apps, schema_editor):
+    """Coerce CVELCM.severity values to CVESeverityChoices via standardize_cvss_severity."""
+    CVELCM = apps.get_model("nautobot_device_lifecycle_mgmt", "CVELCM")
+    for raw in CVELCM.objects.values_list("severity", flat=True).distinct():
+        standardized = standardize_cvss_severity(raw)
+        if standardized != raw:
+            CVELCM.objects.filter(severity=raw).update(severity=standardized)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("nautobot_device_lifecycle_mgmt", "0029_contractlcm_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(code=standardize_cve_severity, reverse_code=migrations.RunPython.noop),
+    ]

--- a/nautobot_device_lifecycle_mgmt/tests/test_utils.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_utils.py
@@ -1,0 +1,70 @@
+"""Tests for utility helpers."""
+
+from nautobot.apps.testing import TestCase
+
+from nautobot_device_lifecycle_mgmt.choices import CVESeverityChoices
+from nautobot_device_lifecycle_mgmt.jobs.cve_tracking import NistCveSyncSoftware
+from nautobot_device_lifecycle_mgmt.utils import standardize_cvss_severity
+
+
+class StandardizeCvssSeverityTest(TestCase):
+    def test_nist_uppercase_values_map_to_choices(self):
+        cases = {
+            "CRITICAL": CVESeverityChoices.CRITICAL,
+            "HIGH": CVESeverityChoices.HIGH,
+            "MEDIUM": CVESeverityChoices.MEDIUM,
+            "LOW": CVESeverityChoices.LOW,
+            "NONE": CVESeverityChoices.NONE,
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(standardize_cvss_severity(raw), expected)
+
+    def test_already_title_cased_values_pass_through(self):
+        for value in (
+            CVESeverityChoices.CRITICAL,
+            CVESeverityChoices.HIGH,
+            CVESeverityChoices.MEDIUM,
+            CVESeverityChoices.LOW,
+            CVESeverityChoices.NONE,
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(standardize_cvss_severity(value), value)
+
+    def test_surrounding_whitespace_is_stripped(self):
+        self.assertEqual(standardize_cvss_severity("  critical  "), CVESeverityChoices.CRITICAL)
+
+    def test_empty_and_none_default_to_none_choice(self):
+        self.assertEqual(standardize_cvss_severity(None), CVESeverityChoices.NONE)
+        self.assertEqual(standardize_cvss_severity(""), CVESeverityChoices.NONE)
+
+    def test_unknown_value_defaults_to_none_and_warns(self):
+        logger_name = "nautobot_device_lifecycle_mgmt"
+        for raw in ("UNDEFINED", "garbage", "extreme"):
+            with self.subTest(raw=raw), self.assertLogs(logger_name, level="WARNING") as captured:
+                self.assertEqual(standardize_cvss_severity(raw), CVESeverityChoices.NONE)
+            self.assertTrue(any("Unrecognized CVSS severity" in message for message in captured.output))
+
+
+class ConvertV2BaseScoreToSeverityTest(TestCase):
+    def test_low_band(self):
+        for score in (0.0, 1.5, 3.9):
+            with self.subTest(score=score):
+                self.assertEqual(NistCveSyncSoftware.convert_v2_base_score_to_severity(score), CVESeverityChoices.LOW)
+
+    def test_medium_band(self):
+        for score in (4.0, 5.0, 6.9):
+            with self.subTest(score=score):
+                self.assertEqual(
+                    NistCveSyncSoftware.convert_v2_base_score_to_severity(score), CVESeverityChoices.MEDIUM
+                )
+
+    def test_high_band(self):
+        for score in (7.0, 8.5, 10.0):
+            with self.subTest(score=score):
+                self.assertEqual(NistCveSyncSoftware.convert_v2_base_score_to_severity(score), CVESeverityChoices.HIGH)
+
+    def test_out_of_band_returns_none(self):
+        for score in (-1.0, 11.0):
+            with self.subTest(score=score):
+                self.assertEqual(NistCveSyncSoftware.convert_v2_base_score_to_severity(score), CVESeverityChoices.NONE)

--- a/nautobot_device_lifecycle_mgmt/tests/test_utils.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_utils.py
@@ -8,6 +8,8 @@ from nautobot_device_lifecycle_mgmt.utils import standardize_cvss_severity
 
 
 class StandardizeCvssSeverityTest(TestCase):
+    """Test the standardize_cvss_severity function."""
+
     def test_nist_uppercase_values_map_to_choices(self):
         cases = {
             "CRITICAL": CVESeverityChoices.CRITICAL,
@@ -47,6 +49,8 @@ class StandardizeCvssSeverityTest(TestCase):
 
 
 class ConvertV2BaseScoreToSeverityTest(TestCase):
+    """Test the convert_v2_base_score_to_severity function."""
+
     def test_low_band(self):
         for score in (0.0, 1.5, 3.9):
             with self.subTest(score=score):

--- a/nautobot_device_lifecycle_mgmt/utils.py
+++ b/nautobot_device_lifecycle_mgmt/utils.py
@@ -1,0 +1,32 @@
+"""Utility helpers for the Device Lifecycle Management app."""
+
+import logging
+
+from nautobot_device_lifecycle_mgmt.choices import CVESeverityChoices
+
+logger = logging.getLogger("nautobot_device_lifecycle_mgmt")
+
+_VALID_SEVERITIES = {choice[0] for choice in CVESeverityChoices.CHOICES}
+
+
+def standardize_cvss_severity(raw: str | None) -> str:
+    """Standardize a raw CVSS severity string to a ``CVESeverityChoices`` value.
+
+    Maps NIST API values (``"CRITICAL"``, ``"HIGH"``, ...) to the title-cased
+    values stored in ``CVELCM.severity``. Unrecognized input falls back to
+    ``CVESeverityChoices.NONE`` with a warning log.
+
+    Args:
+        raw: A severity string from an external source (e.g. NIST CVE API), or
+            ``None``/empty if no severity is available.
+
+    Returns:
+        A valid ``CVESeverityChoices`` value.
+    """
+    if not raw:
+        return CVESeverityChoices.NONE
+    candidate = raw.strip().title()
+    if candidate in _VALID_SEVERITIES:
+        return candidate
+    logger.warning("Unrecognized CVSS severity %r; defaulting to %s", raw, CVESeverityChoices.NONE)
+    return CVESeverityChoices.NONE


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Lifecycle Management! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #566

## What's Changed

The NIST job was haphazardly inserting raw severity strings into CVELCM objects without running any model validation, which could cause data issues. Interestingly enough, if/when a CVE was updated we were at least changing it to use `.title()` which matches the values we are expecting so they would "self-heal" in that regard.

https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/blob/bd6892aa7c2873262aadccce32270247f7cd06c9/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py#L456

In attempt to nip this problem in the bud from the beginning, this PR introduces a util function that helps to standardize CVSS severity strings to values from our `CVESeverityChoices` class. I have updated the NIST job to use this going forward for both the create and update methods.

As this job has already been inserting invalid values up to this point, there's the potential for bad data already. As such, I have also included a migration that will update all existing CVE objects that are using non-standard values.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5272