### PR TITLE
Adding exceptions for HTTP Failures

### DIFF
--- a/changes/582.fixed
+++ b/changes/582.fixed
@@ -1,0 +1,1 @@
+Made the NIST CVE Sync job resilient to transient transport failures (HTTP/2 stream resets surfaced as `ChunkedEncodingError`, `ConnectionError`, and `Timeout`) by closing and re-initializing the NIST session before retrying, up to `retries.max_attempts` with `retries.backoff * attempt` seconds between attempts.

--- a/docs/user/cve_tracking.md
+++ b/docs/user/cve_tracking.md
@@ -83,9 +83,11 @@ An External Integration must be created and configured in order to use the NIST 
 
 - A new External Integration object named ``NAUTOBOT DLM NIST EXTERNAL INTEGRATION`` that allows you to control the following behaviors of the integration:
     - ``api_call_delay``: A delay between API calls in seconds (default: 6).  NIST Recommends a minimum value of 6 to prevent overloading resources.
-    - ``retries``: Even with using a delay, the NIST API may return a 500 error.  The settings in this dictionary allows you to control the number of retries and backoff.
-        - ``max_attempts``: The maximum number of retry attempts (default: 3).
-        - ``backoff``: The backoff factor for the retry attempts (default: 2).  This is the multiplier for the delay between retries.
+    - ``retries``: Controls how the job handles transient failures from the NIST API. There are two retry layers:
+        - HTTP status retries at the session layer (502/503/504).
+        - Transport-level failures at the job layer — `requests.exceptions.ConnectionError`, `ChunkedEncodingError` (e.g., HTTP/2 stream resets such as `Stream X was reset by remote peer`), and `Timeout`. On a transport-level failure the job closes the existing NIST session, re-initializes a fresh one via `nist_session_init`, sleeps `backoff * attempt` seconds, and retries the same URL up to `max_attempts` times before re-raising. HTTP errors and JSON decode errors are not retried at the job layer and propagate immediately.
+        - ``max_attempts``: The maximum number of attempts (default: 3). Used by both layers above.
+        - ``backoff``: The backoff factor for the retry attempts (default: 2). At the session layer this is the urllib3 `backoff_factor`; at the job layer this is the multiplier applied as `backoff * attempt` before each rebuild-and-retry.
 - A new Secrets Group object named ``NAUTOBOT DLM NIST SECRETS GROUP`` used for access to the NIST API Key from the External Integration.
 - A new Secret object named ``NAUTOBOT DLM NIST API KEY``.  This object is created for you during setup with minimum defaults.  The Secret name must be exactly as above, but you will need to configure the Secret to properly access the NIST API Key.
     - To obtain your NIST API Key go [here](https://nvd.nist.gov/developers/request-an-api-key).

--- a/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
+++ b/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
@@ -16,7 +16,8 @@ from nautobot.extras.models import ExternalIntegration
 from netutils.nist import get_nist_urls
 from requests import Session
 from requests.adapters import HTTPAdapter
-from requests.exceptions import HTTPError
+from requests.exceptions import ChunkedEncodingError, HTTPError, Timeout
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.util import Retry
 
 from nautobot_device_lifecycle_mgmt.choices import CVESeverityChoices
@@ -329,25 +330,50 @@ class NistCveSyncSoftware(Job):
     def query_api(self, url: str) -> dict:
         """Query the NIST API for the requested CVE.
 
+        Retries on transient transport failures (remote stream/connection resets) by
+        rebuilding the session, since urllib3 does not auto-retry once a response body
+        has started streaming.
+
         Args:
             url (str): The API endpoint being queried.
 
         Returns:
             dict: Dictionary of returned results if successful.
         """
-        try:
-            result = self.nist_session.get(url)
-            result.raise_for_status()
-            return result.json()
-        except HTTPError as err:
-            code = err.response.status_code
-            self.logger.error(
-                "The NIST Service is currently unavailable. Status Code: %s. Try running the job again later.", code
-            )
-            raise
-        except json.JSONDecodeError as err:
-            self.logger.error("Invalid JSON response from NIST Service: %s", err)
-            raise
+        retries_cfg = self.integration.extra_config.get("retries", {})
+        max_attempts = retries_cfg.get("max_attempts", 3)
+        backoff = retries_cfg.get("backoff", 1)
+
+        last_err = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                result = self.nist_session.get(url)
+                result.raise_for_status()
+                return result.json()
+            except HTTPError as err:
+                code = err.response.status_code
+                self.logger.error(
+                    "The NIST Service is currently unavailable. Status Code: %s. Try running the job again later.", code
+                )
+                raise
+            except json.JSONDecodeError as err:
+                self.logger.error("Invalid JSON response from NIST Service: %s", err)
+                raise
+            except (RequestsConnectionError, ChunkedEncodingError, Timeout) as err:
+                last_err = err
+                if attempt < max_attempts:
+                    self.logger.warning(
+                        "NIST request failure on attempt %s/%s; rebuilding session and retrying. ERROR: %s",
+                        attempt,
+                        max_attempts,
+                        err,
+                    )
+                    self.nist_session.close()
+                    self.nist_session = self.nist_session_init()
+                    sleep(backoff * attempt)
+
+        self.logger.error("NIST request failed after %s attempts. ERROR: %s", max_attempts, last_err)
+        raise last_err
 
     @staticmethod
     def convert_v2_base_score_to_severity(score: float) -> str:

--- a/nautobot_device_lifecycle_mgmt/tests/test_jobs.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_jobs.py
@@ -1,13 +1,17 @@
 """Test Jobs."""
 
+import unittest
 from datetime import date
+from unittest import mock
 
 from django.contrib.contenttypes.models import ContentType
 from nautobot.apps.choices import JobResultStatusChoices
 from nautobot.apps.testing import TransactionTestCase, create_job_result_and_run_job
 from nautobot.dcim.models import Platform, SoftwareVersion
 from nautobot.extras.models import Status
+from requests.exceptions import ChunkedEncodingError, Timeout
 
+from nautobot_device_lifecycle_mgmt.jobs.cve_tracking import NistCveSyncSoftware
 from nautobot_device_lifecycle_mgmt.models import (
     DeviceHardwareNoticeResult,
     DeviceSoftwareValidationResult,
@@ -103,3 +107,80 @@ class DeviceSoftwareValidationFullReportTestCase(TransactionTestCase):
         result_no_sw = DeviceSoftwareValidationResult.objects.get(device=self.devices[2])
         self.assertFalse(result_no_sw.is_validated)
         self.assertIsNone(result_no_sw.software)
+
+
+class NistCveSyncSoftwareQueryApiTestCase(unittest.TestCase):
+    """Test NistCveSyncSoftware.query_api retry/session-rebuild behavior."""
+
+    def _build_job(self, max_attempts=3):
+        """Construct a NistCveSyncSoftware instance with stubbed integration/logger.
+
+        Bypasses Job.__init__ since we only exercise query_api in isolation.
+        """
+        job = NistCveSyncSoftware.__new__(NistCveSyncSoftware)
+        job.logger = mock.MagicMock()
+        job.integration = mock.MagicMock()
+        job.integration.extra_config = {"retries": {"max_attempts": max_attempts, "backoff": 0}}
+        return job
+
+    def test_query_api_rebuilds_session_on_chunked_encoding_error(self):
+        """A ChunkedEncodingError mid-stream rebuilds the session and returns the next response."""
+        failing_session = mock.MagicMock()
+        failing_session.get.side_effect = ChunkedEncodingError("Stream 35 was reset by remote peer. Reason: 0x2.")
+
+        success_response = mock.MagicMock()
+        success_response.json.return_value = {"vulnerabilities": [], "totalResults": 0}
+        rebuilt_session = mock.MagicMock()
+        rebuilt_session.get.return_value = success_response
+
+        job = self._build_job()
+        job.nist_session = failing_session
+        job.nist_session_init = mock.MagicMock(return_value=rebuilt_session)
+
+        with mock.patch("nautobot_device_lifecycle_mgmt.jobs.cve_tracking.sleep"):
+            result = job.query_api("https://example.com/")
+
+        self.assertEqual(result, {"vulnerabilities": [], "totalResults": 0})
+        failing_session.close.assert_called_once()
+        job.nist_session_init.assert_called_once()
+        rebuilt_session.get.assert_called_once_with("https://example.com/")
+
+    def test_query_api_raises_after_exhausting_attempts(self):
+        """When every attempt resets, the original error propagates after max_attempts."""
+        err = ChunkedEncodingError("Stream 35 was reset by remote peer. Reason: 0x2.")
+        failing_session = mock.MagicMock()
+        failing_session.get.side_effect = err
+        rebuilt_session = mock.MagicMock()
+        rebuilt_session.get.side_effect = err
+
+        job = self._build_job(max_attempts=2)
+        job.nist_session = failing_session
+        job.nist_session_init = mock.MagicMock(return_value=rebuilt_session)
+
+        with mock.patch("nautobot_device_lifecycle_mgmt.jobs.cve_tracking.sleep"):
+            with self.assertRaises(ChunkedEncodingError):
+                job.query_api("https://example.com/")
+
+        # session rebuilt once between the two attempts; not rebuilt after the final failure
+        self.assertEqual(job.nist_session_init.call_count, 1)
+
+    def test_query_api_rebuilds_session_on_timeout(self):
+        """A Timeout also triggers session rebuild and retry."""
+        failing_session = mock.MagicMock()
+        failing_session.get.side_effect = Timeout("Read timed out.")
+
+        success_response = mock.MagicMock()
+        success_response.json.return_value = {"vulnerabilities": [], "totalResults": 0}
+        rebuilt_session = mock.MagicMock()
+        rebuilt_session.get.return_value = success_response
+
+        job = self._build_job()
+        job.nist_session = failing_session
+        job.nist_session_init = mock.MagicMock(return_value=rebuilt_session)
+
+        with mock.patch("nautobot_device_lifecycle_mgmt.jobs.cve_tracking.sleep"):
+            result = job.query_api("https://example.com/")
+
+        self.assertEqual(result, {"vulnerabilities": [], "totalResults": 0})
+        failing_session.close.assert_called_once()
+        job.nist_session_init.assert_called_once()


### PR DESCRIPTION
# Closes: #582 

## What's Changed
Now an exception of types RequestsConnectionError, ChunkedEncodingError, Timeout triggers the session to drop and be re-established.